### PR TITLE
Fix: Replace deprecated -extdirs option with -cp in JDK 9+

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -2,7 +2,7 @@ set targetdir=target
 
 IF NOT EXIST "%targetdir%" mkdir %targetdir%
 
-javac -sourcepath src -d %targetdir% -extdirs lib/ src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java
+javac -sourcepath src -d %targetdir% -cp lib/ECLA.jar:lib/DTNConsoleConnection.jar src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java
 
 
 

--- a/compile.sh
+++ b/compile.sh
@@ -2,7 +2,7 @@ targetdir=target
 
 if [ ! -d "$targetdir" ]; then mkdir $targetdir; fi
 
-javac -sourcepath src -d $targetdir -extdirs lib/ src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java
+javac -sourcepath src -d $targetdir -cp lib/ECLA.jar:lib/DTNConsoleConnection.jar src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java
 
 if [ ! -d "$targetdir/gui/buttonGraphics" ]; then cp -R src/gui/buttonGraphics target/gui/; fi
 	


### PR DESCRIPTION
This PR is to solve the following problem:
In JDK 9 and above, the-extdirs option to specify additional class library directories is no longer supported.
JDK 9 Release Notes: https://www.oracle.com/java/technologies/javase/9-relnotes.html

The following quote is from [PR #97](https://github.com/akeranen/the-one/pull/97)
> issue related:
> 
> * resolves [Compilation error on windows 10 #95](https://github.com/akeranen/the-one/issues/95)
> * resolves [Not able to compile: "error: option -extdirs not allowed with target 15" #94](https://github.com/akeranen/the-one/issues/94)
> * resolves [problem with compiling the .bat files #72](https://github.com/akeranen/the-one/issues/72)

The -cp option is also compatible with jdk8, as shown in the figure:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/87376573/229036081-abf22422-6c7b-4e8c-bab7-34da82fc8661.png">
